### PR TITLE
chore: update go to 1.25.5

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
     - if: matrix.build-mode == 'manual'
       env:
         # fix "go: download go1.22 for linux/amd64: toolchain not available" error
-        GOTOOLCHAIN: "go1.25.4"
+        GOTOOLCHAIN: "go1.25.5"
       run: |
         make go-build
 

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - name: Run Gosec Security Scanner
         env:
-          GOTOOLCHAIN: "go1.25.4"
+          GOTOOLCHAIN: "go1.25.5"
         uses: securego/gosec@6be2b51fd78feca86af91f5186b7964d76cb1256 # v2.22.10
         with:
           args: ./...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: go-imports
       - id: go-unit-tests
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.6.2
+    rev: v2.7.0
     hooks:
       - id: golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/natrontech/alertmanager-uptime-kuma-push
 
-go 1.25.4
+go 1.25.5
 
 require github.com/gofiber/fiber/v2 v2.52.10
 
@@ -9,7 +9,7 @@ require (
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/klauspost/compress v1.18.1 // indirect
+	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/gofiber/fiber/v2 v2.52.10 h1:jRHROi2BuNti6NYXmZ6gbNSfT3zj/8c0xy94GOU5
 github.com/gofiber/fiber/v2 v2.52.10/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/klauspost/compress v1.18.1 h1:bcSGx7UbpBqMChDtsF28Lw6v/G94LPrrbMbdC3JH2co=
-github.com/klauspost/compress v1.18.1/go.mod h1:ZQFFVG+MdnR0P+l6wpXgIL4NTtwiKIdBnrBd8Nrxr+0=
+github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
+github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
<!--
Thank you for contributing to natrontech/alertmanager-uptime-kuma-push.
-->

**What this PR does**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Notes for Reviewer**:


**Checklist**:

- [x] I have read and understood the [CONTRIBUTING](https://github.com/natrontech/alertmanager-uptime-kuma-push/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/natrontech/alertmanager-uptime-kuma-push/blob/main/CODE_OF_CONDUCT.md) documents
- [x] All commits are signed (see [Signing Commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification))
- [x] Pull Request title in the format of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) e.g. `feat|fix|chore|docs|...: Changed Something`
- [x] Updated documentation in the  `README.md` file (e.g. new parameters, environment variables, return values, ...) 