### PR TITLE
fix: bump GOTOOLCHAIN to go1.26.4 to match go.mod

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
     - if: matrix.build-mode == 'manual'
       env:
         # fix "go: download go1.22 for linux/amd64: toolchain not available" error
-        GOTOOLCHAIN: "go1.26.3"
+        GOTOOLCHAIN: "go1.26.4"
       run: |
         make go-build
 

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - name: Run Gosec Security Scanner
         env:
-          GOTOOLCHAIN: "go1.26.3"
+          GOTOOLCHAIN: "go1.26.4"
         uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770 # v2.26.1
         with:
           args: ./...


### PR DESCRIPTION
## What

Bump the pinned `GOTOOLCHAIN` from `go1.26.3` to `go1.26.4` in `codeql.yml` and `gosec.yml`.

## Why

`go.mod` now requires Go `1.26.4` (stdlib security fixes). These two workflows pin `GOTOOLCHAIN` to an exact toolchain and do not auto-download, so they still ran `go1.26.3` and failed to build:

```
go: go.mod requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=go1.26.3)
```

This bump re-syncs the pinned toolchain with `go.mod`, fixing the `Analyze (go)` (CodeQL) and gosec builds on `main`.